### PR TITLE
Implement portfolio reload method and tests

### DIFF
--- a/tests/test_portfolio.py
+++ b/tests/test_portfolio.py
@@ -1,0 +1,23 @@
+import json
+from user_data.portfolio import Portfolio
+
+
+def test_load_portfolio_reloads(tmp_path):
+    tmp_file = tmp_path / "portfolio.json"
+    initial = {"AAPL": {"quantity": 1, "costBasis": 100}}
+    updated = {"AAPL": {"quantity": 2, "costBasis": 200}}
+
+    with open(tmp_file, "w") as f:
+        json.dump(initial, f)
+
+    p = Portfolio()
+    p.portfolio_file = str(tmp_file)
+    p.load_portfolio()
+    assert p.get_holdings() == initial
+
+    with open(tmp_file, "w") as f:
+        json.dump(updated, f)
+
+    p.load_portfolio()
+    assert p.get_holdings() == updated
+

--- a/user_data/portfolio.py
+++ b/user_data/portfolio.py
@@ -33,6 +33,11 @@ class Portfolio:
         logger.info("portfolio.json not found. Starting with an empty portfolio.")
         return {}
 
+    def load_portfolio(self) -> None:
+        """Reload portfolio holdings from the JSON file."""
+        self._holdings = self._load_portfolio_from_file()
+        logger.info("Portfolio reloaded from file.")
+
     def save_portfolio(self):
         """
         Saves the current portfolio holdings to the JSON file.


### PR DESCRIPTION
## Summary
- add `load_portfolio` to refresh holdings from file with logging
- test that portfolio data reloads when the JSON file changes

## Testing
- `pytest tests/test_portfolio.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689815511a40832598c5c139c18f9a34