### PR TITLE
test: assert portfolio reload logging

### DIFF
--- a/tests/test_portfolio.py
+++ b/tests/test_portfolio.py
@@ -2,7 +2,7 @@ import json
 from user_data.portfolio import Portfolio
 
 
-def test_load_portfolio_reloads(tmp_path):
+def test_load_portfolio_reloads(tmp_path, caplog):
     tmp_file = tmp_path / "portfolio.json"
     initial = {"AAPL": {"quantity": 1, "costBasis": 100}}
     updated = {"AAPL": {"quantity": 2, "costBasis": 200}}
@@ -12,12 +12,16 @@ def test_load_portfolio_reloads(tmp_path):
 
     p = Portfolio()
     p.portfolio_file = str(tmp_file)
-    p.load_portfolio()
+    with caplog.at_level("INFO"):
+        p.load_portfolio()
     assert p.get_holdings() == initial
+    assert "Portfolio reloaded from file." in caplog.text
 
     with open(tmp_file, "w") as f:
         json.dump(updated, f)
 
-    p.load_portfolio()
+    caplog.clear()
+    with caplog.at_level("INFO"):
+        p.load_portfolio()
     assert p.get_holdings() == updated
-
+    assert "Portfolio reloaded from file." in caplog.text

--- a/user_data/portfolio.py
+++ b/user_data/portfolio.py
@@ -4,11 +4,13 @@ from utils.logging import get_logger
 
 logger = get_logger(__name__)
 
+
 class Portfolio:
     """
     Manages the local portfolio storage for the simulation (test) mode.
     Handles loading, saving, and updating portfolio holdings.
     """
+
     def __init__(self):
         self.portfolio_file = "user_data/portfolio.json"
         self._holdings = self._load_portfolio_from_file()
@@ -20,15 +22,19 @@ class Portfolio:
         """
         if os.path.exists(self.portfolio_file):
             try:
-                with open(self.portfolio_file, 'r') as f:
+                with open(self.portfolio_file, "r") as f:
                     holdings = json.load(f)
                     logger.info("Portfolio loaded successfully from file.")
                     return holdings
             except json.JSONDecodeError as e:
-                logger.error(f"Error decoding portfolio.json: {e}. Starting with empty portfolio.")
+                logger.error(
+                    f"Error decoding portfolio.json: {e}. Starting with empty portfolio."
+                )
                 return {}
             except Exception as e:
-                logger.error(f"Error loading portfolio.json: {e}. Starting with empty portfolio.")
+                logger.error(
+                    f"Error loading portfolio.json: {e}. Starting with empty portfolio."
+                )
                 return {}
         logger.info("portfolio.json not found. Starting with an empty portfolio.")
         return {}
@@ -43,7 +49,7 @@ class Portfolio:
         Saves the current portfolio holdings to the JSON file.
         """
         try:
-            with open(self.portfolio_file, 'w') as f:
+            with open(self.portfolio_file, "w") as f:
                 json.dump(self._holdings, f, indent=4)
             logger.info("Portfolio saved successfully to file.")
         except Exception as e:
@@ -61,28 +67,32 @@ class Portfolio:
         For sales, quantity can be 0 or negative to reduce/remove.
         """
         if quantity < 0:
-            logger.error(f"Cannot add negative quantity for {symbol}. Use reduce_holding or handle sale logic.")
+            logger.error(
+                f"Cannot add negative quantity for {symbol}. Use reduce_holding or handle sale logic."
+            )
             return
 
         # Ensure costBasis is correctly managed on additions/updates.
         # This simplified logic assumes average cost for additions.
         if symbol in self._holdings:
-            existing_quantity = self._holdings[symbol]['quantity']
-            existing_total_cost = existing_quantity * self._holdings[symbol]['costBasis']
+            existing_quantity = self._holdings[symbol]["quantity"]
+            existing_total_cost = (
+                existing_quantity * self._holdings[symbol]["costBasis"]
+            )
 
             new_total_cost = existing_total_cost + (quantity * average_cost)
             new_total_quantity = existing_quantity + quantity
 
-            self._holdings[symbol]['quantity'] = new_total_quantity
-            self._holdings[symbol]['costBasis'] = new_total_cost / new_total_quantity if new_total_quantity > 0 else 0
+            self._holdings[symbol]["quantity"] = new_total_quantity
+            self._holdings[symbol]["costBasis"] = (
+                new_total_cost / new_total_quantity if new_total_quantity > 0 else 0
+            )
         else:
-            self._holdings[symbol] = {
-                'quantity': quantity,
-                'costBasis': average_cost
-            }
+            self._holdings[symbol] = {"quantity": quantity, "costBasis": average_cost}
         self.save_portfolio()
-        logger.info(f"Updated holding for {symbol}: Quantity={self._holdings[symbol]['quantity']}, Avg. Cost=${self._holdings[symbol]['costBasis']:.2f}")
-
+        logger.info(
+            f"Updated holding for {symbol}: Quantity={self._holdings[symbol]['quantity']}, Avg. Cost=${self._holdings[symbol]['costBasis']:.2f}"
+        )
 
     def remove_holding(self, symbol: str):
         """
@@ -93,7 +103,9 @@ class Portfolio:
             self.save_portfolio()
             logger.info(f"Removed {symbol} from portfolio.")
 
-    def update_holding(self, symbol: str, new_quantity: int, new_cost_basis: float = None):
+    def update_holding(
+        self, symbol: str, new_quantity: int, new_cost_basis: float | None = None
+    ):
         """
         Directly updates the quantity and optionally the cost basis of a holding.
         Use with caution for sales where average cost needs recalculation.
@@ -103,10 +115,12 @@ class Portfolio:
             return
 
         if symbol in self._holdings:
-            self._holdings[symbol]['quantity'] = new_quantity
+            self._holdings[symbol]["quantity"] = new_quantity
             if new_cost_basis is not None:
-                self._holdings[symbol]['costBasis'] = new_cost_basis
-            logger.info(f"Directly updated {symbol} holding to quantity {new_quantity}.")
+                self._holdings[symbol]["costBasis"] = new_cost_basis
+            logger.info(
+                f"Directly updated {symbol} holding to quantity {new_quantity}."
+            )
             self.save_portfolio()
         else:
             logger.warning(f"Attempted to update non-existent holding: {symbol}.")


### PR DESCRIPTION
## Summary
- add caplog assertions verifying portfolio reload logging
- annotate `new_cost_basis` as optional to satisfy mypy

## Testing
- `pre-commit run --files tests/test_portfolio.py`
- `pre-commit run --files user_data/portfolio.py`
- `pytest tests/test_portfolio.py::test_load_portfolio_reloads -q`
- `pytest -q` *(fails: ETradeCredentialsMissing in TokenManager)*

------
https://chatgpt.com/codex/tasks/task_e_68981df5b3748325a715dd266a8b9b1f