### PR TITLE
Add sandbox E*Trade endpoints and credential inputs

### DIFF
--- a/etrade_api/api_connection.py
+++ b/etrade_api/api_connection.py
@@ -79,7 +79,7 @@ class ETradeAPIConnection:
         """
         # Using sandbox URLs for development as per standard practice
         request_token_url = "https://apisb.etrade.com/oauth/request_token"
-        authorize_url = "https://us.etrade.com/oauth/authorize"
+        authorize_url = "https://apisb.etrade.com/oauth/authorize"
         access_token_url = "https://apisb.etrade.com/oauth/access_token"
 
         # Step 1: Get a Request Token

--- a/etrade_api/market_data.py
+++ b/etrade_api/market_data.py
@@ -12,7 +12,8 @@ class MarketData:
         Initializes MarketData with an ETradeAPIConnection instance.
         """
         self.api_connection = api_connection
-        self.base_url = "https://api.etrade.com/v1" # Base URL for E*Trade API
+        # Use the E*Trade sandbox environment by default
+        self.base_url = "https://apisb.etrade.com/v1"
 
     def _make_api_call(self, endpoint, params=None):
         """
@@ -133,7 +134,7 @@ class MarketData:
             dict: A dictionary containing news headlines and implied sentiment.
                   Returns an empty dictionary if data cannot be fetched.
         """
-        # E*Trade API has a news endpoint: https://api.etrade.com/v1/market/news.json
+        # E*Trade API has a news endpoint: https://apisb.etrade.com/v1/market/news.json
         endpoint = "market/news.json"
         params = {"symbols": symbol} # Filter news by symbol
         data = self._make_api_call(endpoint, params)

--- a/etrade_api/trading.py
+++ b/etrade_api/trading.py
@@ -12,7 +12,8 @@ class Trading:
         Initializes Trading with an ETradeAPIConnection instance.
         """
         self.api_connection = api_connection
-        self.base_url = "https://api.etrade.com/v1" # Base URL for E*Trade API
+        # Use the E*Trade sandbox environment by default
+        self.base_url = "https://apisb.etrade.com/v1"
 
     def _make_api_call(self, endpoint, params=None):
         """Helper to make authenticated GET requests to the E*Trade API."""


### PR DESCRIPTION
## Summary
- move credential entry into main window and display simulated portfolio when unauthenticated
- switch all E*TRADE API endpoints to sandbox URLs

## Testing
- `QT_QPA_PLATFORM=offscreen python main.py` *(fails: No recommended backend was available for keyring)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689cc7a225b883259069a80a8e927b71